### PR TITLE
Fix for installation on VS2019

### DIFF
--- a/DebugAttachHistory/source.extension.vsixmanifest
+++ b/DebugAttachHistory/source.extension.vsixmanifest
@@ -22,6 +22,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Update source.extension.vsixmanifest to support Visual Studio 2019