### PR TITLE
Update vsixmanifest for VS2019

### DIFF
--- a/DebugAttachHistory/source.extension.vsixmanifest
+++ b/DebugAttachHistory/source.extension.vsixmanifest
@@ -21,6 +21,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Microsoft.VisualStudio.Component.CoreEditor prerequisite should have an open-ended upper bound for VS2019 support according to:
https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/

Fixes this error:
The extension with ID 'facf6f74-1cc6-44be-b57d-115d48b30021' is not installed to Microsoft Visual Studio Community 2019.
Extension cannot be installed to the following products due to missing prerequisites:
	Microsoft Visual Studio Community 2019
		-------------------------------------------------------
		Identifier   : Microsoft.VisualStudio.Component.CoreEditor
		Name         : Visual Studio core editor
		Version      : [12.0,16.0)
		Error        : The prerequisite version specified does not match the version installed